### PR TITLE
Add script to download fresh dogfood-setup.sh every time.

### DIFF
--- a/dogfood-setup-new.sh
+++ b/dogfood-setup-new.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# download and run the newest dogfood-setup.sh
+curl -SsL https://raw.github.com/mozilla-b2g/dogfood-setup/master/dogfood-setup.sh | sh -s $1


### PR DESCRIPTION
`dogfood-setup-new.sh` downloads `dogfood-setup.sh` via `curl` every
time and executes it while also passing the first argument in. This
approach is nice because it doesn't cache the script, so every run will
get the latest script. The down side is that internet access is
required, but if they're flashing, they probably just downloaded the
image.

Might be best to rename the real script to something else and call the
new one `dogfood-setup.sh` and instruct people to download it one last
time (if we like this approach).

This is what I'm doing locally. Hope it helps.
